### PR TITLE
Fix for running react scripts test

### DIFF
--- a/example/index.tsx
+++ b/example/index.tsx
@@ -11,13 +11,13 @@ const StyledText = styled(ReactFitty)`
     font-family: 'Roboto', 'Helvetica', 'Arial', sans-serif;
 `;
 
-const flexDiv = {
+const flexDiv: React.CSSProperties = {
     height: "50%",
     width: "100%",
     display: "flex",
     justifyContent: "center",
     alignItems: "center",
-    textAlign: "center"
+    textAlign: "center",
 };
 
 const App = () => {
@@ -26,7 +26,7 @@ const App = () => {
             {/* todo support style and className on Wrapper(root div) */}
             <ReactFitty style={{ width: '10%' }}>Mussum Ipsum, cacilds</ReactFitty>
 
-            <div style={...flexDiv}>
+            <div style={{ ...flexDiv }}>
                 <ReactFitty>TEST1</ReactFitty>
             </div>
 

--- a/example/package.json
+++ b/example/package.json
@@ -14,13 +14,13 @@
   "alias": {
     "react": "../node_modules/react",
     "react-dom": "../node_modules/react-dom/profiling",
-    "scheduler/tracing": "../node_modules/scheduler/tracing-profiling",
+    "scheduler/tracing": "../node_modules/react-dom/node_modules/scheduler/tracing-profiling",
     "fitty": "../node_modules/fitty"
   },
   "devDependencies": {
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
-    "parcel": "^1.12.4",
+    "parcel": "^1.12.3",
     "typescript": "^4.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     }
   ],
   "devDependencies": {
+    "@babel/core": "^7.12.7",
+    "@babel/preset-env": "^7.12.7",
     "@babel/preset-typescript": "^7.12.7",
     "@size-limit/preset-small-lib": "^4.9.1",
     "@skypack/package-check": "^0.2.2",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,14 @@
 import React from 'react';
-import fitty from 'fitty';
+
+// In order to use react-scripts test, we need to "require" fitty instead of importing.
+// Otherwise, react-scripts test will result in error messages saying
+// SyntaxError: Unexpected token 'export'
+// This error stems from trying to import the  dist/fitty.module.js rollup file which is
+// the fitty package's main file.  Therefore, we need to explicitly require the
+// fitty.min.js file instead.
+//
+// See https://github.com/rikschennink/fitty/issues/76
+const fitty = require('fitty/dist/fitty.min.js');
 
 const fullWidth = { width: '100%' };
 


### PR DESCRIPTION
When trying to mount components via enzyme for testing, if a component is using react-fitty then tests will fail with an error messaging saying `"SyntaxError: Unexpected token 'export'`.  This is due to the fitty package's main rollup file `fitty.module.js`

To resolve the error, react-fitty needs to be updated to use
```const fitty = require('fitty/dist/fitty.min.js');```

instead of 
```import fitty from 'fitty';```

This PR also includes updates to run tests locally.